### PR TITLE
Make table-magic understand SQL

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
     <nav class="tabnav-tabs">
       <a href="#" class="tabnav-tab selected" id="tab-csv" onclick="changeTab('csv');"><span class="octicon octicon-file-text"></span> CSV/TSV</a>
       <a href="#" class="tabnav-tab" id="tab-md" onclick="changeTab('md');"><span class="octicon octicon-code"></span> Markdown</a>
+      <a href="#" class="tabnav-tab" id="tab-sql" onclick="changeTab('sql');"><span class="octicon octicon-database"></span> SQL</a>
       <a href="#" class="tabnav-tab" id="tab-html" onclick="changeTab('html');"><span class="octicon octicon-file-code"></span> HTML</a>
       <a href="#" class="tabnav-tab" id="tab-form" onclick="changeTab('form');"><span class="octicon octicon-pencil"></span> Form</a>
       <a href="#" class="tabnav-tab" id="tab-preview" onclick="changeTab('preview');"><span class="octicon octicon-browser"></span> Preview</a>

--- a/index.html
+++ b/index.html
@@ -45,8 +45,8 @@
 
   <div id="sql-info">
     <p class="note">
-    Read about the SQL function <a href="">in this issue</a>.
-    <p class="note">
+    Read about the SQL function <a href="https://github.com/stevecat/table-magic/pull/20">in this pull request</a>.
+    </div>
   </div>
 
 

--- a/index.html
+++ b/index.html
@@ -43,6 +43,12 @@
     </div>
   </div>
 
+  <div id="sql-info">
+    <p class="note">
+    Read about the SQL function <a href="">in this issue</a>.
+    <p class="note">
+  </div>
+
 
 <div class="footer">
   built by <a href="http://www.github.com/stevecat/">stevecat</a> &bull;

--- a/magic.js
+++ b/magic.js
@@ -507,15 +507,18 @@ var html = "    <tr>\n";
 
 function sql2array(sql) {
 
-  // Find first + on a new line, allows the query to be included.
   var row = 0, col = -1, line = 0, cursor = 0, start = false, step = "pre",
       columns = 0, thisCell="", array=[], skip = false;
 
   for (var c = 0; c < sql.length; c++) {
 
-    if (sql[c]==="\n") line++;
+    // Find first + on a new line, allows the query to be included.
+    if ( ((sql[c]==="\n")&&(sql[c+1]==="+")) || ((line===0)&&(sql[c]==="+")) ) {
+      start = true;
+      c++;
+    }
 
-    if ( ((sql[c]==="\n")&&(sql[c+1]==="+")) || ((line===0)&&(sql[c]==="+")) ) start = true;
+    if (sql[c]==="\n") line++;
 
     if (start) {
       // Table has begun.

--- a/magic.js
+++ b/magic.js
@@ -16,7 +16,7 @@ $(window).load(function() {
   layout(true);
 
   if (tab!=="md") { $('#md-options').hide(); }
-  if (tab!=="import") { $('#import-options').hide(); }
+  if (tab!="sql") { $('#sql-info').hide(); }
 
   // bind form buttons
   $("body").delegate(".button-row-duplicate", "click", function() {
@@ -140,12 +140,14 @@ function changeTab(newTab) {
 
       if ((tab==='md')||tab==='sql') {
         $('textarea').removeClass('md');
-        $('#md-options').hide();
+        if (tab==='md') $('#md-options').hide();
+        if (tab==='sql') $('#sql-info').hide();
       }
 
       if ((newTab==='md')||newTab==='sql') {
         $('textarea').addClass('md');
-        $('#md-options').show();
+        if (newTab==='md') $('#md-options').show();
+        if (newTab==='sql') $('#sql-info').show();
       }
 
       // Update variables

--- a/magic.js
+++ b/magic.js
@@ -86,6 +86,7 @@ function changeTab(newTab) {
       if (tab==="md") { array = md2array(input); }
       if (tab==="csv") { array = csv2array(input); }
       if (tab==="html") { array = html2array(input); }
+      if (tab==="sql") { array = sql2array(input); }
       if (tab==="form") { array = form2array(); }
       if (tab==="preview") { array = array_storge; }
 
@@ -104,6 +105,11 @@ function changeTab(newTab) {
 
       if (newTab==="html") {
         output = array2html(array);
+        new_layout=true;
+      }
+
+      if (newTab==="sql") {
+        output = array2sql(array);
         new_layout=true;
       }
 
@@ -496,6 +502,95 @@ var html = "    <tr>\n";
   html += "    </tr>\n";
 
   return html;
+
+}
+
+function sql2array(sql) {
+
+  // Find first + on a new line, allows the query to be included.
+  var row = 0, col = -1, line = 0, cursor = 0, start = false, step = "pre",
+      columns = 0, thisCell="", array=[], skip = false;
+
+  for (var c = 0; c < sql.length; c++) {
+
+    if (sql[c]==="\n") line++;
+
+    if ( ((sql[c]==="\n")&&(sql[c+1]==="+")) || ((line===0)&&(sql[c]==="+")) ) start = true;
+
+    if (start) {
+      // Table has begun.
+
+      if (step==="pre") {
+        // Collecting column count.
+        if (sql[c]==="+") columns ++;
+        if (sql[c]==="\n") {
+          step="header";
+          array[0]=[];
+          c++;
+        }
+      }
+
+      if (step==="header") {
+        // Collecting the headers
+        if (sql[c]==="|") {
+          if (col>-1) array[0][col]=thisCell.trim();
+          col++;
+          thisCell="";
+        } else {
+          thisCell=thisCell+sql[c];
+        }
+        if (sql[c]==="\n") {
+          step="wait";
+          c++;
+        }
+      }
+
+      if (step==="wait") {
+        // Skim through the line under the header
+        if (sql[c]==="\n") {
+          step="data";
+          row=1;
+          col=-1;
+          thisCell="";
+          array[row]=[];
+          c++;
+        }
+      }
+
+      if (step==="data") {
+        // Reading data from table
+        if (sql[c]==="|") {
+          if (col>-1) {
+            if (col===0) array[row]=[];
+            array[row][col]=thisCell.trim();
+          }
+          col++;
+          thisCell="";
+        } else {
+          thisCell=thisCell+sql[c];
+        }
+        if (sql[c]==="\n") {
+          row++;
+          col=-1;
+          thisCell="";
+        }
+        if ((sql[c]==="+")&&(sql[c-1]=="\n")) {
+           // Complete.
+           step="end";
+        }
+
+      }
+
+    }
+
+  }
+
+  return array;
+
+}
+
+function array2sql(array) {
+
 
 }
 

--- a/magic.js
+++ b/magic.js
@@ -513,7 +513,7 @@ function sql2array(sql) {
   for (var c = 0; c < sql.length; c++) {
 
     // Find first + on a new line, allows the query to be included.
-    if ( ((sql[c]==="\n")&&(sql[c+1]==="+")) || ((line===0)&&(sql[c]==="+")) ) {
+    if ( (((sql[c]==="\n")&&(sql[c+1]==="+")) || ((line===0)&&(sql[c]==="+"))) && (!start) ) {
       start = true;
       c++;
     }

--- a/magic.js
+++ b/magic.js
@@ -138,12 +138,12 @@ function changeTab(newTab) {
       $('.tabnav-tab').removeClass('selected');
       $('#tab-'+newTab).addClass('selected');
 
-      if (tab==='md') {
+      if ((tab==='md')||tab==='sql') {
         $('textarea').removeClass('md');
         $('#md-options').hide();
       }
 
-      if (newTab==='md') {
+      if ((newTab==='md')||newTab==='sql') {
         $('textarea').addClass('md');
         $('#md-options').show();
       }
@@ -628,9 +628,15 @@ function array2sql(array) {
           }
 
       }
-
       md += " |";
-      if (r<array.length) { md += "\n"; }
+
+      if (r<(array.length-1)) {
+        md += "\n";
+      } else {
+        md += "\n"+array2sqlDashes(cell_sizes, row.length);
+      }
+
+      if (r==0) { md += array2sqlDashes(cell_sizes, row.length)+"\n"; }
 
   }
 
@@ -640,7 +646,7 @@ function array2sql(array) {
 
 function array2sqlDashes(cell_sizes, rowlength) {
 
-  var line = "";
+  var line = "+";
 
   for (var c = 0; c < rowlength; c++) {
 
@@ -649,10 +655,10 @@ function array2sqlDashes(cell_sizes, rowlength) {
       var spaces = cell_sizes[c] + 2;
 
       for (var s = 0; s < spaces; s++) {
-        line += "+";
+        line += "-";
       }
 
-    line+="|";
+    line+="+";
 
   }
 

--- a/magic.js
+++ b/magic.js
@@ -591,6 +591,72 @@ function sql2array(sql) {
 
 function array2sql(array) {
 
+  var md = "", cell_sizes = [];
+
+  // Gather max cell sizes for each column.
+  for (var r = 0; r < array.length; r++) {
+    for (var c = 0; c < array[r].length; c++) {
+      if ( (!cell_sizes[c]) || (array[r][c].length>cell_sizes[c]) ) {
+        cell_sizes[c]=array[r][c].length;
+      }
+    }
+  }
+
+  for (var r = 0; r < array.length; r++) {
+
+      var row = array[r];
+
+      if (r==0) { md += array2sqlDashes(cell_sizes, row.length)+"\n"; }
+
+      for (var c = 0; c < row.length; c++) {
+
+        var item = row[c];
+
+        // Output
+        if (c>0) { md += " "; }
+        md += "| ";
+        md += item;
+
+          // Add spaces to fill the gaps
+          var spaces = cell_sizes[c] - item.length;
+
+          // Must always be at least 3
+          if ((spaces<1)&&(item.length===0)) { spaces=1; }
+
+          for (var s = 0; s < spaces; s++) {
+            md += " ";
+          }
+
+      }
+
+      md += " |";
+      if (r<array.length) { md += "\n"; }
+
+  }
+
+  return md;
+
+}
+
+function array2sqlDashes(cell_sizes, rowlength) {
+
+  var line = "";
+
+  for (var c = 0; c < rowlength; c++) {
+
+    var dashes="";
+
+      var spaces = cell_sizes[c] + 2;
+
+      for (var s = 0; s < spaces; s++) {
+        line += "+";
+      }
+
+    line+="|";
+
+  }
+
+  return line;
 
 }
 


### PR DESCRIPTION
This adds an "SQL" tab to table-magic, this allows it to interpret the tables produced by MySQL's command line interface. For example:

```
+------+-------+-------+
| Item | Value | Count |
+------+-------+-------+
| Ham  | 6     | 20.00 |
| Spam | 2     | 6.40  |
| Eggs | 12    | 2.00  |
+------+-------+-------+
```

Can become:

| Item | Value | Count |
|------|-------|-------|
| Ham  | 6     | 20.00 |
| Spam | 2     | 6.40  |
| Eggs | 12    | 2.00  |