### PR TITLE
Improving the form tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@
   built by <a href="http://www.github.com/stevecat/">stevecat</a> &bull;
   <a href="http://www.github.com/stevecat/table-magic">repo</a> &bull;
   <a href="http://www.github.com/stevecat/table-magic/issues">issues</a> &bull;
-  <a href="#" onclick="fill_example();"><strong>populate with example data</strong></a>
+  <a href="#" onclick="fill_example();">populate with example data</a>
 </div>
 
 </div>

--- a/index.html
+++ b/index.html
@@ -32,20 +32,20 @@
 
   <div class="form-tools">
 
-    <div class="form-button" id="tablebuilder-start">
-      N
+    <div class="form-button" id="tablebuilder-start" title="Drag out a new table">
+      <span class="octicon octicon-plus"></span> New table
     </div>
 
-    <div class="form-button" id="new-row">
-      R
+    <div class="form-button" id="new-row" title="Add a row to the bottom">
+      <span class="octicon octicon-triangle-down"></span> Add  row
     </div>
 
-    <div class="form-button" id="new-column">
-      C
+    <div class="form-button" id="new-column" title="Add a column to the right">
+      <span class="octicon octicon-triangle-right"></span> Add column
     </div>
 
-    <div class="form-button" id="toggle-delete">
-      D
+    <div class="form-button" id="toggle-delete" title="Toggle deletion of rows and columns">
+      <span class="octicon octicon-trashcan"></span> Enable deletion
     </div>
 
   </div>

--- a/index.html
+++ b/index.html
@@ -30,7 +30,33 @@
     </nav>
   </div>
 
+  <div class="form-tools">
+
+    <div class="form-button" id="tablebuilder-start">
+      N
+    </div>
+
+    <div class="form-button" id="new-row">
+      R
+    </div>
+
+    <div class="form-button" id="new-column">
+      C
+    </div>
+
+    <div class="form-button" id="toggle-delete">
+      D
+    </div>
+
+  </div>
+
+</div>
+<div class="container" id="viewport">
+
   <div id="display"></div>
+
+</div>
+<div class="container">
 
   <div id="csv-options" class="options">
     <p>
@@ -55,7 +81,6 @@
     Read about the SQL function <a href="https://github.com/stevecat/table-magic/pull/20">in this pull request</a>.
     </p>
   </div>
-
 
 <div class="footer">
   built by <a href="http://www.github.com/stevecat/">stevecat</a> &bull;

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
 
 <div class="masthead">
   <div class="container">
-    <div class="title one-fourth column">table-magic</div>
+    <div class="title">table-magic</div>
   </div>
 </div>
 

--- a/magic.js
+++ b/magic.js
@@ -997,14 +997,14 @@ function array2form(array) {
       var row = array[r];
 
       if (r===0) { fontweight="bold;" } else { fontweight="normal"; }
-      html += "<tr style=\"font-weight:"+fontweight+"\">";
+      html += "<tr style=\"font-weight:"+fontweight+"\" class=\"row"+r+"\">";
 
       for (var c = 0; c < row.length; c++) {
 
         var item = row[c];
         item = item.replace(/"/g, '&quot;'); // replace "s
 
-        html += "<td>";
+        html += "<td class=\"col"+c+"\">";
         html += "<input id='form-"+r+"-"+c+"' value=\"";
         html += item;
         html += "\"";
@@ -1015,8 +1015,9 @@ function array2form(array) {
 
       html += "<td class=\"button\">"+
               //"<button class=\"btn btn-sm button-row-duplicate\" type=\"button\"><span class=\"octicon octicon-repo-forked\"></span></button> "+
-              "<button class=\"btn-formmod button-row-remove"+button_class+"\" type=\"button\" title=\"Delete row\"><span class=\"octicon octicon-trashcan\"></span></button>"+
-              "</td>";
+              "<button class=\"btn-formmod button-row-remove"+button_class+"\" type=\"button\" title=\"Delete row\""+
+              " onmouseenter=\"del_row_hl("+r+", true);\"  onmouseleave=\"del_row_hl("+r+", false);\">"+
+              "<span class=\"octicon octicon-trashcan\"></span></button></td>";
 
 
 
@@ -1040,7 +1041,9 @@ function array2form(array) {
       for (var c = 0; c < form_cols; c++) {
         html += "<td class=\"button\" align=\"center\">"+
                 //"<button class=\"btn btn-sm button-col-duplicate\" type=\"button\"><span class=\"octicon octicon-repo-forked\"></span></button> "+
-                "<button class=\"btn-formmod button-col-remove"+button_class+"\" type=\"button\" title=\"Delete column\"><span class=\"octicon octicon-trashcan\"></span></button>"+
+                "<button class=\"btn-formmod button-col-remove"+button_class+"\" type=\"button\" title=\"Delete column\""+
+                "onmouseenter=\"del_col_hl("+c+", true);\"  onmouseleave=\"del_col_hl("+c+", false);\""+
+                "><span class=\"octicon octicon-trashcan\"></span></button>"+
                 "</td>";
       }
 
@@ -1183,6 +1186,22 @@ function form_remove_col(col) {
   // Redraw
   form_redraw(array);
 
+}
+
+function del_row_hl(row, active) {
+  if (active) {
+    $('.row'+row).addClass('delHighlight');
+  } else {
+    $('.row'+row).removeClass('delHighlight');
+  }
+}
+
+function del_col_hl(col, active) {
+  if (active) {
+    $('.col'+col).addClass('delHighlight');
+  } else {
+    $('.col'+col).removeClass('delHighlight');
+  }
 }
 
 function form_resize() {

--- a/magic.js
+++ b/magic.js
@@ -1075,9 +1075,21 @@ function md2html(md) {
 
 // form modification
 function form_redraw(array) {
+
+  // Save scroll position:
+  var scrolled = $('#viewport').scrollLeft();
+
+  // Redraw the form!
   var html = array2form(array);
   $('.preview').html(html);
+
+  // Resize cells
   form_resize();
+
+  // Restore scroll position, we first scroll one pixel to force
+  // Chrome on OSX to show the scrollbars.
+  $('#viewport').scrollLeft(1).scrollLeft(scrolled);
+
 }
 
 function form_add_row() {
@@ -1218,7 +1230,6 @@ function form_resize() {
 
     if ((global_form_cols>5)&&(global_form_cols<13)) {
       $('#viewport').css('width', '100%');
-      console.log('yo')
     }
 
     if (global_form_cols>12) {

--- a/magic.js
+++ b/magic.js
@@ -1,4 +1,4 @@
-var tab = "csv", header_alignment=[], array_storage="", form_rows=0, form_cols=0, prettify_md=true, debug=false, global_form_cols=0;
+var tab = "csv", header_alignment=[], array_storage="", form_rows=0, form_cols=0, prettify_md=true, debug=false, global_form_cols=0, delete_mode=false;
 
 var example_csv='Feature, Description, Example\n'+
                 'Renders markdown, Uses showdown library to render contents of table cells, **Just** *like* ``this``\n'+
@@ -30,7 +30,19 @@ $(window).load(function() {
     });
 
     $("body").delegate("#toggle-delete", "click", function() {
-      $('table.form td.button').toggle();
+
+      if (delete_mode) {
+        delete_mode=false;
+        $('.btn-formmod.show').removeClass('show');
+        $('#toggle-delete').removeClass('active');
+        $('#toggle-delete').html("<span class=\"octicon octicon-trashcan\"></span> Enable deletion");
+      } else {
+        delete_mode=true;
+        $('.btn-formmod').addClass('show');
+        $('#toggle-delete').addClass('active');
+        $('#toggle-delete').html("<span class=\"octicon octicon-trashcan\"></span> Disable deletion");
+      }
+
      });
 
   $("body").delegate(".button-row-duplicate", "click", function() {
@@ -71,6 +83,12 @@ $(window).load(function() {
         $('textarea').val(md);
       }
 
+    });
+
+    $( window ).resize(function() {
+      if (tab==="form") {
+        form_resize();
+      }
     });
 
     // Table-builder
@@ -190,6 +208,8 @@ function changeTab(newTab) {
 
       if (tab==='form') {
         $('.form-tools').hide();
+        $('#viewport').removeAttr('style');
+        $('table.form').removeClass('scroll');
       }
 
 
@@ -968,7 +988,9 @@ function array2form(array) {
 
 
 
-  var html = "<table class=form><thead>";
+  var html = "<table class=form><thead>", button_class="";
+
+  if (delete_mode) button_class = " show";
 
   for (var r = 0; r < array.length; r++) {
 
@@ -993,7 +1015,7 @@ function array2form(array) {
 
       html += "<td class=\"button\">"+
               //"<button class=\"btn btn-sm button-row-duplicate\" type=\"button\"><span class=\"octicon octicon-repo-forked\"></span></button> "+
-              "<button class=\"btn-formmod button-row-remove\" type=\"button\" title=\"Delete row\"><span class=\"octicon octicon-trashcan\"></span></button>"+
+              "<button class=\"btn-formmod button-row-remove"+button_class+"\" type=\"button\" title=\"Delete row\"><span class=\"octicon octicon-trashcan\"></span></button>"+
               "</td>";
 
 
@@ -1018,7 +1040,7 @@ function array2form(array) {
       for (var c = 0; c < form_cols; c++) {
         html += "<td class=\"button\" align=\"center\">"+
                 //"<button class=\"btn btn-sm button-col-duplicate\" type=\"button\"><span class=\"octicon octicon-repo-forked\"></span></button> "+
-                "<button class=\"btn-formmod button-col-remove\" type=\"button\" title=\"Delete column\"><span class=\"octicon octicon-trashcan\"></span></button>"+
+                "<button class=\"btn-formmod button-col-remove"+button_class+"\" type=\"button\" title=\"Delete column\"><span class=\"octicon octicon-trashcan\"></span></button>"+
                 "</td>";
       }
 
@@ -1165,19 +1187,43 @@ function form_remove_col(col) {
 
 function form_resize() {
 
-  // <6 - scaled in display
-  // 6>12 - display 150%
-  // 12>20 - scaled in container
-  // >20 - container scrolls
-  console.log(global_form_cols);
-  $('#viewport').removeAttr('style');
+  // <640px, scaling until 6 fields
+  // 640>1024, scaling until 11 fields
+  // >1024, centered+scaling until 6, 100% and scaling until 12
 
-  if (global_form_cols<6) {
-    //
+  var window_size = $( window ).width();
+  $('#viewport').removeAttr('style');
+  $('table.form').removeClass('scroll');
+
+  if (window_size>1024) {
+
+    if ((global_form_cols>5)&&(global_form_cols<13)) {
+      $('#viewport').css('width', '100%');
+      console.log('yo')
+    }
+
+    if (global_form_cols>12) {
+      $('#viewport').css('width', '100%');
+      $('#viewport').css('overflow-x', 'scroll');
+      $('table.form').addClass('scroll');
+    }
+
   }
 
-  if ((global_form_cols>5)&&(global_form_cols<13)) {
-    $('#viewport').css('width', '75%');
+  if ( (window_size>640) && (window_size<1025) ) {
+
+    if (global_form_cols>8) {
+      $('#viewport').css('overflow-x', 'scroll');
+      $('table.form').addClass('scroll');
+    }
+
+  }
+
+  if (window_size<=640) {
+    if (global_form_cols>5) {
+      $('#viewport').css('overflow-x', 'scroll');
+      $('table.form').addClass('scroll');
+    }
   }
 
 }

--- a/styles.css
+++ b/styles.css
@@ -125,6 +125,7 @@ button.btn-formmod:hover {
 
   table.form.scroll {
     table-layout: fixed;
+    margin-bottom:7px;
   }
 
   table.form.scroll td {

--- a/styles.css
+++ b/styles.css
@@ -13,6 +13,7 @@ color:#fff;
 .masthead .title {
   font-weight:bold;
   font-size:1.3em;
+  padding-left:10px;
 }
 
 .masthead .sub {
@@ -176,3 +177,24 @@ input.header {
 .table-builder div div.first { border-left:2px solid #BE3B77; }
 .table-builder div.first div.last { border-top:2px solid #ccc; }
 .table-builder div.last div.first { border-left:2px solid #ccc; }
+
+/* let's get responsive.. */
+@media all and (max-width: 1024px) {
+  .container {
+    width:100%;
+    padding:0px 5px;
+  }
+}
+@media all and (max-width: 650px) {
+  .tabnav-tab {
+    padding:3px 6px;
+    font-size:0.9em;
+  }
+  .masthead {
+    padding-top:0.5rem;
+    padding-bottom:0.5rem;
+  }
+  .masthead .title {
+    padding-left:3px;
+  }
+}

--- a/styles.css
+++ b/styles.css
@@ -114,6 +114,10 @@ button.btn-formmod:hover {
   color:#c42222;
 }
 
+.delHighlight, .delHighlight input {
+  background-color: #e4aeae !important;
+}
+
 /* form scaling */
   table.form {
     width:100%;

--- a/styles.css
+++ b/styles.css
@@ -94,24 +94,37 @@ table.form input:focus {
   outline:0;
 }
 
-table.form td.button {
-  display:none;
-}
-
 button.btn-formmod {
+  display:none;
   border:none;
   background-color: #fff;
   color:#615f5f;
   border-radius: 2px;
 }
 
+button.btn-formmod.show {
+  display:block;
+}
+
 button.btn-formmod:hover {
   color:#dd1010;
+}
+
+#toggle-delete.active {
+  color:#c42222;
 }
 
 /* form scaling */
   table.form {
     width:100%;
+  }
+
+  table.form.scroll {
+    table-layout: fixed;
+  }
+
+  table.form.scroll td {
+    width:170px;
   }
 
 input.header {
@@ -126,15 +139,26 @@ input.header {
 
 .form-tools {
   overflow:hidden;
+  margin-top:-10px;
   margin-bottom:10px;
 }
 
 .form-tools .form-button {
   float:left;
-  background-color: red;
-  width:20px;
-  width:20px;
+  waidth:20px;
+  height:20px;
   margin:5px;
+  margin-right:12px;
+  padding-top:2px;
+  color:#878787;
+  border-radius: 2px;
+  text-align: center;
+  cursor:pointer;
+  user-select: none;
+}
+
+.form-tools .form-button:hover {
+  color:#000;
 }
 
 .form-tools .form-button.tablePos {
@@ -157,8 +181,8 @@ input.header {
 
 .table-builder div div {
   display:table-cell;
-  height:20px;
-  width:20px;
+  height:40px;
+  width:40px;
   border-bottom:2px solid #BE3B77;
   border-right:2px solid #BE3B77;
   background-color: #ead7e0;
@@ -185,7 +209,7 @@ input.header {
     padding:0px 5px;
   }
 }
-@media all and (max-width: 650px) {
+@media all and (max-width: 640px) {
   .tabnav-tab {
     padding:3px 6px;
     font-size:0.9em;

--- a/styles.css
+++ b/styles.css
@@ -76,6 +76,43 @@ table.form thead td.button,  table.form tbody td.button  {
   border: 1px solid #fff;
 }
 
+table.form td {
+  padding: 3px 4px;
+}
+
+table.form tr:nth-child(2n) input {
+    background-color: #f8f8f8;
+}
+
+table.form input {
+  border:none;
+  width:98%;
+}
+
+table.form input:focus {
+  outline:0;
+}
+
+table.form td.button {
+  display:none;
+}
+
+button.btn-formmod {
+  border:none;
+  background-color: #fff;
+  color:#615f5f;
+  border-radius: 2px;
+}
+
+button.btn-formmod:hover {
+  color:#dd1010;
+}
+
+/* form scaling */
+  table.form {
+    width:100%;
+  }
+
 input.header {
   font-weight:bold;
 }
@@ -85,3 +122,57 @@ input.header {
   text-align:center;
   color:#9d9d9d;
 }
+
+.form-tools {
+  overflow:hidden;
+  margin-bottom:10px;
+}
+
+.form-tools .form-button {
+  float:left;
+  background-color: red;
+  width:20px;
+  width:20px;
+  margin:5px;
+}
+
+.form-tools .form-button.tablePos {
+  margin-top:-10px;
+}
+
+.table-button {
+  position:absolute;
+  z-index: 1;
+}
+
+.table-builder {
+  display:table;
+  padding:10px 40px 40px 10px;
+}
+
+.table-builder div {
+  display:table-row;
+}
+
+.table-builder div div {
+  display:table-cell;
+  height:20px;
+  width:20px;
+  border-bottom:2px solid #BE3B77;
+  border-right:2px solid #BE3B77;
+  background-color: #ead7e0;
+}
+
+.table-builder { cursor: pointer; }
+
+.table-builder div.last div, .table-builder div div.last {
+  border-bottom:2px solid #ccc;
+  border-right:2px solid #ccc;
+  background-color: #fff;
+}
+
+/* stop the top and left borders over-running.. */
+.table-builder div.first div { border-top:2px solid #BE3B77; }
+.table-builder div div.first { border-left:2px solid #BE3B77; }
+.table-builder div.first div.last { border-top:2px solid #ccc; }
+.table-builder div.last div.first { border-left:2px solid #ccc; }


### PR DESCRIPTION
This PR adds functionality to the Form tab, including:

* Designed to look more like a table with shading and full-size text boxes
* A "New table" button that allows you to drag out the size of your table
* Toggle delete buttons
* Rows and columns are highlighted when deleting
* Form (and all of table-magic) is now responsive. Cells are resized and scrollbars added when things start getting tiny.

![tbmagicform](https://cloud.githubusercontent.com/assets/12534592/26240588/33b54df6-3c8a-11e7-9603-c81600f338cb.gif)

This also *removes* the duplicate row/column button. I can't say I ever used it. Let me know if this is missed and I can add it back.

:cat: